### PR TITLE
fix: add defaultSort parameter to fetchAllWithPagination

### DIFF
--- a/marketplace/src/app/state/market/market-state.effects.ts
+++ b/marketplace/src/app/state/market/market-state.effects.ts
@@ -187,7 +187,7 @@ export class MarketStateEffects {
     ofType(marketStateActions.setMarketSlug),
     distinctUntilChanged((a, b) => a.marketSlug === b.marketSlug),
     switchMap(({ marketSlug }) => {
-      return this.dataSvc.fetchAllWithPagination(marketSlug, 0, 110, {}).pipe(
+      return this.dataSvc.fetchAllWithPagination(marketSlug, 0, 110, {}, defaultSort['all']).pipe(
         map((data: MarketState['activeMarketRouteData']) => data.data)
       );
     }),


### PR DESCRIPTION
## Fix: Add defaultSort parameter to fetchAllWithPagination

### Problem
When running locally, the "all" items preview fails to load without explicitly passing the sort parameter. This causes the market view to appear empty.

### Solution
Pass `defaultSort['all']` to `fetchAllWithPagination` in the `fetchAll$` effect.

### Testing
- Verified locally on Sepolia testnet
- Items now load correctly in preview mode

### Notes
I noticed production works fine at sepolia.etherphunks.eth.limo - this may be an environment-specific issue or already fixed in unreleased code, but this ensures the public codebase works for local development.