### PR TITLE
feat: extend indexer ethscription creation support for additional content types

### DIFF
--- a/indexer/src/modules/ethscriptions/ethscriptions.service.ts
+++ b/indexer/src/modules/ethscriptions/ethscriptions.service.ts
@@ -53,11 +53,21 @@ export class EthscriptionsService {
     const stringData = hexToString(input.toString() as `0x${string}`);
     const cleanedString = stringData.replace(/\x00/g, '');
 
-    // Check if possible ethPhunk creation
+    // Check if possible ethscription creation (any supported content type)
     const possibleEthPhunk =
       cleanedString.startsWith('data:image/svg+xml,') ||
       cleanedString.startsWith('data:image/png;base64,') ||
-      cleanedString.startsWith('data:image/gif;base64,');
+      cleanedString.startsWith('data:image/gif;base64,') ||
+      cleanedString.startsWith('data:image/jpeg;base64,') ||
+      cleanedString.startsWith('data:image/jpg;base64,') ||
+      cleanedString.startsWith('data:image/webp;base64,') ||
+      cleanedString.startsWith('data:image/avif;base64,') ||
+      cleanedString.startsWith('data:video/webm;base64,') ||
+      cleanedString.startsWith('data:text/html,') ||
+      cleanedString.startsWith('data:text/html;charset=utf-8,') ||
+      cleanedString.startsWith('data:application/json,') ||
+      cleanedString.startsWith('data:application/json;charset=utf-8,') ||
+      cleanedString.startsWith('data:application/pdf;base64,');
 
     if (possibleEthPhunk) {
       const sha = createHash('sha256').update(cleanedString).digest('hex');


### PR DESCRIPTION
This pull request expands the detection logic for supported ethscription content types in the `EthscriptionsService`. The change makes it possible to recognize a wider variety of content types beyond the previously supported image formats.

Content type support enhancements:

* Updated the check for possible ethscription creation to include additional content types such as JPEG, JPG, WEBP, AVIF images, WEBM videos, HTML, JSON, and PDF (both with and without charset specifications), in addition to the previously supported SVG, PNG, and GIF formats.