### PR TITLE
fix: stabilize collection route refresh and recent activity

### DIFF
--- a/marketplace/src/app/components/phunk-grid/phunk-grid.component.html
+++ b/marketplace/src/app/components/phunk-grid/phunk-grid.component.html
@@ -7,7 +7,7 @@
   @if (data) {
     @for (
       phunk of data;
-      track phunk.sha;
+      track phunk.event?.txId || phunk.sha;
       let i = $index;
     ) {
       @if (i < limit) {

--- a/marketplace/src/app/services/data.service.ts
+++ b/marketplace/src/app/services/data.service.ts
@@ -836,13 +836,14 @@ export class DataService {
     };
 
     // Initial fetch
-    const rpcFetch$: Observable<Collection[]> = from(
+    const rpcFetch$: Observable<Collection[]> = defer(() => from(
       supabase.rpc(
         'fetch_collections_with_previews' + this.suffix,
         params
       )
-    ).pipe(
+    )).pipe(
       map((res: any) => {
+        if (res.error) throw res.error;
         if (!res.data) return [];
         return res.data
           .map((item: any) => ({
@@ -856,6 +857,14 @@ export class DataService {
             }
             return true;
           });
+      }),
+      retry({
+        count: 2,
+        delay: (_err, retryCount) => timer(retryCount * 500),
+      }),
+      catchError((err) => {
+        console.warn('Failed to fetch collections', { onlyDisabled, err });
+        return of([]);
       }),
       // tap((res) => console.log('fetchCollections', res)),
     );

--- a/marketplace/src/app/services/data.service.ts
+++ b/marketplace/src/app/services/data.service.ts
@@ -5,7 +5,7 @@ import { Store } from '@ngrx/store';
 
 import { createClient, RealtimePostgresUpdatePayload, RealtimePostgresInsertPayload } from '@supabase/supabase-js'
 
-import { Observable, of, from, forkJoin, firstValueFrom, EMPTY, timer, merge, filter, share, catchError, debounceTime, expand, map, reduce, switchMap, tap, distinctUntilChanged, BehaviorSubject } from 'rxjs';
+import { Observable, of, from, forkJoin, firstValueFrom, EMPTY, timer, merge, filter, share, catchError, debounceTime, expand, map, reduce, switchMap, tap, distinctUntilChanged, BehaviorSubject, defer, retry } from 'rxjs';
 
 import { Web3Service } from '@/services/web3.service';
 import { AttributesService } from '@/services/attributes.service';
@@ -316,19 +316,21 @@ export class DataService {
     type: EventType,
     slug: string,
   ): Observable<Event[]> {
-    const query = supabase.rpc(
-      'fetch_events' + this.suffix,
-      {
-        p_limit: limit,
-        p_type: type && type !== 'All' ? type : null,
-        p_collection_slug: slug,
-        p_offset: offset,
-      }
-    );
-
-    const rpcFetch$ = from(query).pipe(
+    const rpcFetch$ = defer(() => from(
+      supabase.rpc(
+        'fetch_events' + this.suffix,
+        {
+          p_limit: limit,
+          p_type: type && type !== 'All' ? type : null,
+          p_collection_slug: slug,
+          p_offset: offset,
+        }
+      )
+    )).pipe(
       map((res: any) => {
-        const result = res.data?.map((tx: any) => {
+        if (res.error) throw res.error;
+
+        const result = (res.data || []).map((tx: any) => {
           let type = tx.type;
           if (type === 'transfer') {
             if (tx.to?.toLowerCase() === environment.bridgeAddress) type = 'bridgeOut';
@@ -337,6 +339,14 @@ export class DataService {
           return { ...tx, type, } as Event;
         });
         return result;
+      }),
+      retry({
+        count: 2,
+        delay: (_err, retryCount) => timer(retryCount * 500),
+      }),
+      catchError((err) => {
+        console.warn('Failed to fetch recent activity events', { slug, type, offset, err });
+        return of([]);
       }),
     );
 

--- a/marketplace/src/app/state/data/data-state.effects.ts
+++ b/marketplace/src/app/state/data/data-state.effects.ts
@@ -13,8 +13,9 @@ import * as dataStateActions from '@/state/data/data-state.actions';
 import * as dataStateSelectors from '@/state/data/data-state.selectors';
 
 import * as marketStateSelectors from '@/state/market/market-state.selectors';
+import * as marketStateActions from '@/state/market/market-state.actions';
 
-import { filter, map, switchMap, take, tap } from 'rxjs';
+import { distinctUntilChanged, filter, map, switchMap, take, withLatestFrom } from 'rxjs';
 
 @Injectable()
 export class DataStateEffects {
@@ -46,15 +47,18 @@ export class DataStateEffects {
   ));
 
   setActiveCollection$ = createEffect(() => this.actions$.pipe(
-    ofType(dataStateActions.setCollections),
-    switchMap((action) => {
-      return this.store.select(marketStateSelectors.selectMarketSlug).pipe(
-        filter(() => !!action.collections),
-        map((slug) => action.collections.find((c) => c.slug === slug)),
-        filter((activeCollection) => !!activeCollection),
-        map((activeCollection) => dataStateActions.setActiveCollection({ activeCollection: { ...activeCollection! } }))
-      );
-    }),
+    ofType(
+      dataStateActions.setCollections,
+      marketStateActions.setMarketSlug,
+    ),
+    withLatestFrom(
+      this.store.select(dataStateSelectors.selectCollections),
+      this.store.select(marketStateSelectors.selectMarketSlug),
+    ),
+    map(([, collections, slug]) => collections.find((c) => c.slug === slug)),
+    filter((activeCollection) => !!activeCollection),
+    distinctUntilChanged((a, b) => a?.slug === b?.slug),
+    map((activeCollection) => dataStateActions.setActiveCollection({ activeCollection: { ...activeCollection! } }))
   ));
 
   fetchLeaderboard$ = createEffect(() => this.actions$.pipe(

--- a/marketplace/src/app/state/market/market-state.effects.ts
+++ b/marketplace/src/app/state/market/market-state.effects.ts
@@ -160,6 +160,12 @@ export class MarketStateEffects {
     map((events) => dataStateActions.setEvents({ events })),
   ));
 
+  clearEventsOnMarketSlugChange$ = createEffect(() => this.actions$.pipe(
+    ofType(marketStateActions.setMarketSlug),
+    distinctUntilChanged((a, b) => a.marketSlug === b.marketSlug),
+    map(() => dataStateActions.setEvents({ events: [] })),
+  ));
+
   setActionData$ = createEffect(() => this.actions$.pipe(
     ofType(marketStateActions.setMarketData),
     map(({ marketData }) => marketData.filter((item) => !!item.auction)),

--- a/marketplace/src/app/state/market/market-state.effects.ts
+++ b/marketplace/src/app/state/market/market-state.effects.ts
@@ -154,10 +154,13 @@ export class MarketStateEffects {
           if (page === 0) return events;
           return [...acc, ...events];
         }, [] as Event[]),
+        map((events) => ({ events, marketSlug })),
       );
     }),
+    withLatestFrom(this.store.select(marketStateSelectors.selectMarketSlug)),
+    filter(([{ marketSlug }, currentMarketSlug]) => marketSlug === currentMarketSlug),
     // tap((events) => console.log('fetchEvents$', events)),
-    map((events) => dataStateActions.setEvents({ events })),
+    map(([{ events }]) => dataStateActions.setEvents({ events })),
   ));
 
   clearEventsOnMarketSlugChange$ = createEffect(() => this.actions$.pipe(

--- a/marketplace/src/app/state/market/market-state.reducers.ts
+++ b/marketplace/src/app/state/market/market-state.reducers.ts
@@ -44,9 +44,20 @@ export const marketStateReducer: ActionReducer<MarketState, Action> = createRedu
     return setMarketType
   }),
   on(actions.setMarketSlug, (state, { marketSlug }) => {
+    if (state.marketSlug === marketSlug) return state;
+
     const setMarketSlug = {
       ...state,
-      marketSlug
+      marketSlug,
+      marketData: initialState.marketData,
+      owned: initialState.owned,
+      listings: initialState.listings,
+      bids: initialState.bids,
+      all: initialState.all,
+      auctions: initialState.auctions,
+      activeMarketRouteData: initialState.activeMarketRouteData,
+      selectedPhunks: initialState.selectedPhunks,
+      pagination: initialState.pagination,
     };
     return setMarketSlug;
   }),

--- a/supabase/migrations/20250128000000_add_event_activity_query_indexes.sql
+++ b/supabase/migrations/20250128000000_add_event_activity_query_indexes.sql
@@ -1,0 +1,35 @@
+CREATE INDEX IF NOT EXISTS ethscriptions_slug_hash_id_idx
+ON public.ethscriptions (slug, "hashId");
+
+CREATE INDEX IF NOT EXISTS events_hash_id_block_timestamp_tx_id_idx
+ON public.events ("hashId", "blockTimestamp" DESC, "txId");
+
+CREATE INDEX IF NOT EXISTS events_type_hash_id_block_timestamp_tx_id_idx
+ON public.events (type, "hashId", "blockTimestamp" DESC, "txId");
+
+CREATE INDEX IF NOT EXISTS events_recent_activity_order_idx
+ON public.events ("blockTimestamp" DESC, "txId", "hashId")
+INCLUDE ("from", "to", type, value)
+WHERE
+  type <> 'PhunkNoLongerForSale'
+  AND "to" <> '0xd3418772623be1a3cc6b6d45cb46420cedd9154a'
+  AND "to" <> ''
+  AND "from" <> '';
+
+CREATE INDEX IF NOT EXISTS ethscriptions_sepolia_slug_hash_id_idx
+ON public.ethscriptions_sepolia (slug, "hashId");
+
+CREATE INDEX IF NOT EXISTS events_sepolia_hash_id_block_timestamp_tx_id_idx
+ON public.events_sepolia ("hashId", "blockTimestamp" DESC, "txId");
+
+CREATE INDEX IF NOT EXISTS events_sepolia_type_hash_id_block_timestamp_tx_id_idx
+ON public.events_sepolia (type, "hashId", "blockTimestamp" DESC, "txId");
+
+CREATE INDEX IF NOT EXISTS events_sepolia_recent_activity_order_idx
+ON public.events_sepolia ("blockTimestamp" DESC, "txId", "hashId")
+INCLUDE ("from", "to", type, value)
+WHERE
+  type <> 'PhunkNoLongerForSale'
+  AND "to" <> '0x3dfbc8c62d3ce0059bdaf21787ec24d5d116fe1e'
+  AND "to" <> '0xc6a824d8cce7c946a3f35879694b9261a36fc823'
+  AND "from" <> '0xc6a824d8cce7c946a3f35879694b9261a36fc823';


### PR DESCRIPTION
## Summary
- clear collection-specific market state when switching collection routes so stale listings/items do not remain visible
- refresh the active collection when either collections or the active slug changes
- ignore stale recent-activity responses when switching collections quickly
- add retry/error logging around recent activity and collection preview RPC calls
- add indexes for collection recent-activity queries used by `fetch_events`

## Context
While browsing the live upstream production marketplace UI, I noticed collection pages could get into a stale or partially-loaded state when moving between collections.

The main symptoms I saw were:
- switching from one collection to another could leave stale `For Sale`, `All`, or owned item data from the previous collection visible
- Recent Activity sometimes stayed blank until refreshing the page or navigating away and back
- on larger collections, Recent Activity could be noticeably slow to populate
- occasionally the collections dropdown did not populate on first load until a refresh
- repeated fast collection switching made the stale/blank states easier to reproduce

This appears to be a combination of route reuse/state timing issues and slower Recent Activity queries. The UI can reuse the same mounted route component while only the slug changes, so collection-specific state needs to be cleared/refreshed explicitly. Separately, `fetch_events` benefits from indexes that match the collection activity lookup pattern.

## Notes
This branch is based directly on `upstream/development` and intentionally excludes unrelated attribute-order/main-traits work.

## Testing
- Reproduced similar behavior while switching quickly between collections
- Verified the route/state refresh and Recent Activity behavior locally after the changes
- `git diff --check`
- TypeScript check was not run successfully because this clean upstream branch does not include a local generated `marketplace/src/environments/environment.ts`
